### PR TITLE
Add section for Vendor response and metadata for dates

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,9 +45,16 @@ end of the file.
 
 <if there are any>
 
+## DNS Operator/Vendor Response
+
+<if there's any>
+
 ## Metadata
 
 Submitter: <may be used if the source is not a commit>
+Submit-Date: <date>
+Report-Date: <date> <upstream-contact>
+Fixed-Date: <date>
 Tags: <free form tags for the DVE as a comma seperated list>
 <meta-data>: <value>
 ```


### PR DESCRIPTION
I think we should also encouraged submitting the issues to the vendors/operators, so adding a fields to record response and hopefully the date of the fix should encourage such behavior.