### PR TITLE
DVE-2017-0015

### DIFF
--- a/2017/DVE-2017-0015.md
+++ b/2017/DVE-2017-0015.md
@@ -1,0 +1,87 @@
+# DVE-2017-0015: (fixed) Cloudflare omits NS from NSEC type bit map in response to DS query for insecure delegation
+
+## Description
+
+`nominet.uk` is hosted on the Cloudflare DNS servers, and signed.
+`info.nominet.uk` is an unsigned delegation to non-Cloudflare DNS servers.
+
+DS queries for `info.nominet.uk` get an NSEC response denying DS presence (correct) and NS presence (incorrect).
+This makes it impossible for validators to trust the insecure delegation.
+
+## Evidence
+
+    ; <<>> DiG 9.11.0a2 <<>> ds info.nominet.uk @dee.ns.cloudflare.com +dnssec +multiline +norec
+    ;; global options: +cmd
+    ;; Got answer:
+    ;; ->>HEADER<<- opcode: QUERY, status: NOERROR, id: 60534
+    ;; flags: qr aa; QUERY: 1, ANSWER: 0, AUTHORITY: 4, ADDITIONAL: 1
+
+    ;; OPT PSEUDOSECTION:
+    ; EDNS: version: 0, flags: do; udp: 512
+    ;; QUESTION SECTION:
+    ;info.nominet.uk.   IN DS
+
+    ;; AUTHORITY SECTION:
+    nominet.uk.     3600 IN SOA curt.ns.cloudflare.com. dns.cloudflare.com. (
+                    2024237512 ; serial
+                    10000      ; refresh (2 hours 46 minutes 40 seconds)
+                    2400       ; retry (40 minutes)
+                    604800     ; expire (1 week)
+                    3600       ; minimum (1 hour)
+                    )
+    info.nominet.uk.    3600 IN NSEC \000.info.nominet.uk. A WKS HINFO MX TXT AAAA LOC SRV CERT SSHFP IPSECKEY RRSIG NSEC TLSA HIP OPENPGPKEY SPF
+    nominet.uk.     3600 IN RRSIG SOA 13 2 3600 (
+                    20170406214655 20170404194655 35273 nominet.uk.
+                    gV2vgOna53Ps/w6MXi43DZ3onU+A99360rktPudTrb3i
+                    PhbIzGzLyGwb/8mhvL4mWhzuBBPOwa92b20Gkl0b+w== )
+    info.nominet.uk.    3600 IN RRSIG NSEC 13 3 3600 (
+                    20170406214655 20170404194655 35273 nominet.uk.
+                    x5lME11SI8fRh9QXwLwH6RX68siBB/NPyS4c8Xsw8nsn
+                    0gys9gXLJAhg8rR5fss+j1RxeYR1qKMJL97LMsquQg== )
+
+    ;; Query time: 24 msec
+    ;; SERVER: 2400:cb00:2049:1::adf5:3a5d#53(2400:cb00:2049:1::adf5:3a5d)
+    ;; WHEN: Wed Apr 05 22:46:55 CEST 2017
+    ;; MSG SIZE  rcvd: 364
+
+DNSViz also reports the error: http://dnsviz.net/d/info.nominet.uk/WOVKhg/dnssec/ - hovering over the NSEC box inside nominet.uk shows "NSEC proving non-existence of info.nominet.uk/DS: The NS bit was not set in the bitmap of the NSEC RR corresponding to the delegated name (info.nominet.uk)."
+
+## Proposed fix
+
+Return the same NSEC as you would for a non-DS query:
+
+    ; <<>> DiG 9.11.0a2 <<>> a info.nominet.uk @dee.ns.cloudflare.com +dnssec +multiline +norec
+    ;; global options: +cmd
+    ;; Got answer:
+    ;; ->>HEADER<<- opcode: QUERY, status: NOERROR, id: 32381
+    ;; flags: qr; QUERY: 1, ANSWER: 0, AUTHORITY: 5, ADDITIONAL: 1
+
+    ;; OPT PSEUDOSECTION:
+    ; EDNS: version: 0, flags: do; udp: 512
+    ;; QUESTION SECTION:
+    ;info.nominet.uk.   IN A
+
+    ;; AUTHORITY SECTION:
+    info.nominet.uk.    300 IN NS ns1.dns.dotmailer.co.uk.
+    info.nominet.uk.    300 IN NS ns2.dns.dotmailer.co.uk.
+    info.nominet.uk.    300 IN NS ns0.dns.dotmailer.co.uk.
+    info.nominet.uk.    3600 IN NSEC info\000.nominet.uk. NS RRSIG NSEC
+    info.nominet.uk.    3600 IN RRSIG NSEC 13 3 3600 (
+                    20170406221657 20170404201657 35273 nominet.uk.
+                    0y/BAXm7hgjRSL7HhgxnzRi2v1ZM1hquHySEhUl+j1DO
+                    yNehHqPoiydXftxjjBbay+l0qE5vrK7eTI2kwhcTMg== )
+
+    ;; Query time: 25 msec
+    ;; SERVER: 2400:cb00:2049:1::adf5:3a5d#53(2400:cb00:2049:1::adf5:3a5d)
+    ;; WHEN: Wed Apr 05 23:16:57 CEST 2017
+    ;; MSG SIZE  rcvd: 259
+
+Incidentally this would also fix the problem that the DS response claims knowledge about a next name (`\000.info.nominet.uk`) that CloudFlare has no authority over.
+
+## Metadata
+
+Submitter: Peter van Dijk
+Submit-Date: 2017-04-05
+Report-Date: 2017-04-05
+Fixed-Date: 2017-04-07
+Tags: protocol, dnssec


### PR DESCRIPTION
Cloudflare omits NS from NSEC type bit map in response to DS query for insecure delegation