### PR TITLE
Remove duplicate Submit-Date metadata

### DIFF
--- a/2017/DVE-2017-0016.md
+++ b/2017/DVE-2017-0016.md
@@ -48,4 +48,5 @@ application/dns+dnstap: `DVE-2017-0016/pkt-IN_A_dns.google.com._@ns1.google.com.
 
 Submitter: Robert Edmonds
 Submit-Date: 2017-05-09
+Report-Date: 2017-05-09
 Tags: protocol

--- a/2017/DVE-2017-0016.md
+++ b/2017/DVE-2017-0016.md
@@ -48,5 +48,4 @@ application/dns+dnstap: `DVE-2017-0016/pkt-IN_A_dns.google.com._@ns1.google.com.
 
 Submitter: Robert Edmonds
 Submit-Date: 2017-05-09
-Submit-Date: 2017-05-09
 Tags: protocol


### PR DESCRIPTION
It is meaningless for two metadata records to ever have key and value both equal - submitters should suppress such duplicates if encountered. :-)