### PR TITLE
Add DVE-2017-0019: Adobe nameservers return wrong CNAME on non-A queries

### DIFF
--- a/2017/DVE-2017-0019.md
+++ b/2017/DVE-2017-0019.md
@@ -1,0 +1,168 @@
+# DVE-2017-0019: Adobe nameservers return wrong CNAME on non-A queries
+
+## Description
+
+The domain name 'help.adobe.com' has a CNAME chain that contains 'help.wip4.adobe.com'.
+The nameservers authoritative for 'wip4.adobe.com' (da1gtm001.adobe.com., du1gtm001.adobe.com., sj1gtm001.adobe.com.) answer with a CNAME to 'help.adobe.com.edgesuite.net.wip4.adobe.com.' (note the appended domain name) for any query that is not a simple A query.
+Processing in the authoritative server leads to the target of the CNAME not existing and a an NXDOMAIN response is sent.
+
+This wrong CNAME response is then cached by the recursor and A queries for 'help.adobe.com' will be NXDOMAIN because of this wrong CNAME.
+
+## Evidence
+
+Correct response on A query:
+
+```
+$ dig @du1gtm001.adobe.com. help.wip4.adobe.com A +norec +nocookie
+
+; <<>> DiG 9.11.2 <<>> @du1gtm001.adobe.com. help.wip4.adobe.com A +norec +nocookie
+; (1 server found)
+;; global options: +cmd
+;; Got answer:
+;; ->>HEADER<<- opcode: QUERY, status: NOERROR, id: 5415
+;; flags: qr aa ad; QUERY: 1, ANSWER: 1, AUTHORITY: 0, ADDITIONAL: 1
+
+;; OPT PSEUDOSECTION:
+; EDNS: version: 0, flags:; udp: 4096
+;; QUESTION SECTION:
+;help.wip4.adobe.com.		IN	A
+
+;; ANSWER SECTION:
+help.wip4.adobe.com.	10800	IN	CNAME	help.adobe.com.edgesuite.net.
+
+;; Query time: 57 msec
+;; SERVER: 193.104.215.247#53(193.104.215.247)
+;; WHEN: Tue Aug 15 12:15:34 CEST 2017
+;; MSG SIZE  rcvd: 90
+```
+
+Incorrect CNAME and NXDOMAIN on non-A query:
+
+```
+$ dig @du1gtm001.adobe.com. help.wip4.adobe.com NS +norec +nocookie
+
+; <<>> DiG 9.11.2 <<>> @du1gtm001.adobe.com. help.wip4.adobe.com NS +norec +nocookie
+; (1 server found)
+;; global options: +cmd
+;; Got answer:
+;; ->>HEADER<<- opcode: QUERY, status: NXDOMAIN, id: 58063
+;; flags: qr aa; QUERY: 1, ANSWER: 1, AUTHORITY: 1, ADDITIONAL: 1
+
+;; OPT PSEUDOSECTION:
+; EDNS: version: 0, flags:; udp: 4096
+;; QUESTION SECTION:
+;help.wip4.adobe.com.		IN	NS
+
+;; ANSWER SECTION:
+help.wip4.adobe.com.	10800	IN	CNAME	help.adobe.com.edgesuite.net.wip4.adobe.com.
+
+;; AUTHORITY SECTION:
+wip4.adobe.com.		30	IN	SOA	sj1gtm001.adobe.com. hostmaster.sj1gtm001.adobe.com. 1477 10800 3600 604800 45
+
+;; Query time: 58 msec
+;; SERVER: 193.104.215.247#53(193.104.215.247)
+;; WHEN: Tue Aug 15 12:10:05 CEST 2017
+;; MSG SIZE  rcvd: 148
+```
+
+Incorrect CNAME and NXDOMAIN on an A query with a DNS Cookie:
+
+```
+$ dig @du1gtm001.adobe.com. help.wip4.adobe.com A +norec +cookie
+
+; <<>> DiG 9.11.2 <<>> @du1gtm001.adobe.com. help.wip4.adobe.com A +norec +cookie
+; (1 server found)
+;; global options: +cmd
+;; Got answer:
+;; ->>HEADER<<- opcode: QUERY, status: NXDOMAIN, id: 15089
+;; flags: qr aa; QUERY: 1, ANSWER: 1, AUTHORITY: 1, ADDITIONAL: 1
+
+;; OPT PSEUDOSECTION:
+; EDNS: version: 0, flags:; udp: 4096
+;; QUESTION SECTION:
+;help.wip4.adobe.com.		IN	A
+
+;; ANSWER SECTION:
+help.wip4.adobe.com.	10800	IN	CNAME	help.adobe.com.edgesuite.net.wip4.adobe.com.
+
+;; AUTHORITY SECTION:
+wip4.adobe.com.		30	IN	SOA	sj1gtm001.adobe.com. hostmaster.sj1gtm001.adobe.com. 1477 10800 3600 604800 45
+
+;; Query time: 62 msec
+;; SERVER: 193.104.215.247#53(193.104.215.247)
+;; WHEN: Tue Aug 15 12:57:35 CEST 2017
+;; MSG SIZE  rcvd: 148
+```
+
+### Recursor responses
+
+Right (wrong CNAME not cached):
+
+```
+$ dig @127.0.0.1 help.adobe.com
+
+; <<>> DiG 9.11.2 <<>> @127.0.0.1 help.adobe.com
+; (1 server found)
+;; global options: +cmd
+;; Got answer:
+;; ->>HEADER<<- opcode: QUERY, status: NOERROR, id: 9817
+;; flags: qr rd ra; QUERY: 1, ANSWER: 6, AUTHORITY: 0, ADDITIONAL: 1
+
+;; OPT PSEUDOSECTION:
+; EDNS: version: 0, flags:; udp: 1024
+;; QUESTION SECTION:
+;help.adobe.com.			IN	A
+
+;; ANSWER SECTION:
+help.adobe.com.		10743	IN	CNAME	help.wip4.adobe.com.
+help.wip4.adobe.com.	10743	IN	CNAME	help.adobe.com.edgesuite.net.
+help.adobe.com.edgesuite.net. 21543 IN	CNAME	help.adobe.com.edgesuite.net.globalredir.akadns.net.
+help.adobe.com.edgesuite.net.globalredir.akadns.net. 3543 IN CNAME a630.b.akamai.net.
+a630.b.akamai.net.	20	IN	A	104.93.82.19
+a630.b.akamai.net.	20	IN	A	104.93.82.32
+
+;; Query time: 32 msec
+;; SERVER: 127.0.0.1#53(127.0.0.1)
+;; WHEN: Tue Aug 15 11:59:43 CEST 2017
+;; MSG SIZE  rcvd: 231
+```
+
+With a wrongly cached CNAME:
+
+```
+dig @127.0.0.1 help.adobe.com A
+
+; <<>> DiG 9.11.2 <<>> @127.0.0.1 help.adobe.com A
+; (1 server found)
+;; global options: +cmd
+;; Got answer:
+;; ->>HEADER<<- opcode: QUERY, status: NXDOMAIN, id: 34613
+;; flags: qr rd ra; QUERY: 1, ANSWER: 2, AUTHORITY: 1, ADDITIONAL: 1
+
+;; OPT PSEUDOSECTION:
+; EDNS: version: 0, flags:; udp: 1024
+;; QUESTION SECTION:
+;help.adobe.com.                        IN      A
+
+;; ANSWER SECTION:
+help.adobe.com.         10800   IN      CNAME   help.wip4.adobe.com.
+help.wip4.adobe.com.    10778   IN      CNAME   help.adobe.com.edgesuite.net.wip4.adobe.com.
+
+;; AUTHORITY SECTION:
+wip4.adobe.com.         8       IN      SOA     sj1gtm001.adobe.com. hostmaster.sj1gtm001.adobe.com. 1477 10800 3600 604800 45
+
+;; Query time: 56 msec
+;; SERVER: 127.0.0.1#53(127.0.0.1)
+;; WHEN: Tue Aug 15 12:03:54 CEST 2017
+;; MSG SIZE  rcvd: 167
+```
+
+## Proposed fix
+
+Send identical CNAME responses, regardless of the QTYPE.
+
+## Metadata
+
+Submitter: Pieter Lexis
+Submit-Date: 2017-08-15
+Tags: 


### PR DESCRIPTION
This violation has a few sides, but it comes down to answering a different (wrong) CNAME when the query is not for A or has an EDNS cookie. Leading to a false NXDOMAIN.

This issue is reported to Akamai and Adobe.