### PR TITLE
2017-0013: Move "fixed" to Vendor Response

### DIFF
--- a/2017/DVE-2017-0013.md
+++ b/2017/DVE-2017-0013.md
@@ -6,8 +6,6 @@ authoritative servers are also setting `AD` bit on in all DNS
 responses violating
 [RFC 4035](https://tools.ietf.org/html/rfc4035#section-3.1.6)
 
-This was fixed on 2017-01-30.
-
 ### DNS Response for non-authoritative zone with AD bit set
 
 ```
@@ -36,6 +34,10 @@ while [RFC 4035](https://tools.ietf.org/html/rfc4035#section-3.1.6)
 allows usage of `AD` bit in an Authoritative Response, this doesn't
 seem to be a case of design decision, but simply an implementation
 error.
+
+## DNS Operator/Vendor Response
+
+Issue was fixed on 2017-01-30.
 
 ## Metadata
 


### PR DESCRIPTION
Moved the note of the problem being fixed to the Vendor Response section for consistency with other violation reports.