### PR TITLE
Add DVE about Qwest DNS servers improperly handling unknown EDNS options in request

### DIFF
--- a/2017/DVE-2017-0020.md
+++ b/2017/DVE-2017-0020.md
@@ -1,0 +1,107 @@
+# DVE-2017-0020: Some Qwest DNS servers return an incorrect response to unknown EDNS options in request
+
+## Description
+
+*sauthns1.qwest.net* and *sauthns2.qwest.net* DNS servers respond incorrectly to EDNS requests that contain
+any option unknown to them (for example a *COOKIE* option).
+
+[Section 6.1.1 of RFC 6891](https://tools.ietf.org/html/rfc6891#section-6.1.2) says that:
+>  Any OPTION-CODE values not understood by a responder or requestor MUST be ignored.
+
+These servers, however, respond with an RCODE of *BADVERS* instead.
+
+Many .GOV domains (like *archives.gov*, *arts.gov*, *bea.gov*, etc.) are served by these DNS servers.
+This breaks resolving them by *BIND* 9.10.3+ on Windows and *BIND* 9.11.0+ on all systems since these resolvers
+add a *COOKIE* option to every DNS query by default.
+
+This problem was noticed as early as in [March 2014](https://www.ietf.org/mail-archive/web/dnsext/current/msg13683.html).
+
+## Evidence
+
+### EDNS with *COOKIE* option
+
+```sh
+$ dig +edns +cookie +norecurse archives.gov soa @sauthns1.qwest.net
+; <<>> DiG 9.11.0-P3 <<>> +edns +cookie +norecurse archives.gov soa @sauthns1.qwest.net
+;; global options: +cmd
+;; Got answer:
+;; ->>HEADER<<- opcode: QUERY, status: BADVERS, id: 63779
+;; flags: qr ad; QUERY: 0, ANSWER: 0, AUTHORITY: 0, ADDITIONAL: 1
+
+;; OPT PSEUDOSECTION:
+; EDNS: version: 0, flags:; udp: 4096
+;; Query time: 154 msec
+;; SERVER: 63.150.72.5#53(63.150.72.5)
+;; WHEN: Fri Oct 13 23:42:21 CEST 2017
+;; MSG SIZE  rcvd: 23
+```
+
+```sh
+$ dig +edns +cookie +norecurse archives.gov soa @sauthns2.qwest.net
+; <<>> DiG 9.11.0-P3 <<>> +edns +cookie +norecurse archives.gov soa @sauthns2.qwest.net
+;; global options: +cmd
+;; Got answer:
+;; ->>HEADER<<- opcode: QUERY, status: BADVERS, id: 64465
+;; flags: qr ad; QUERY: 0, ANSWER: 0, AUTHORITY: 0, ADDITIONAL: 1
+
+;; OPT PSEUDOSECTION:
+; EDNS: version: 0, flags:; udp: 4096
+;; Query time: 155 msec
+;; SERVER: 208.44.130.121#53(208.44.130.121)
+;; WHEN: Fri Oct 13 23:47:10 CEST 2017
+;; MSG SIZE  rcvd: 23
+```
+
+### EDNS without options
+
+```sh
+$ dig +edns +nocookie +norecurse archives.gov soa @sauthns1.qwest.net
+; <<>> DiG 9.11.0-P3 <<>> +edns +nocookie +norecurse archives.gov soa @sauthns1.qwest.net
+;; global options: +cmd
+;; Got answer:
+;; ->>HEADER<<- opcode: QUERY, status: NOERROR, id: 49877
+;; flags: qr aa; QUERY: 1, ANSWER: 1, AUTHORITY: 2, ADDITIONAL: 1
+
+;; OPT PSEUDOSECTION:
+; EDNS: version: 0, flags:; udp: 4096
+;; QUESTION SECTION:
+;archives.gov.			IN	SOA
+
+;; ANSWER SECTION:
+archives.gov.		300	IN	SOA	sauthns2.qwest.net. dns-admin.qwestip.net. 2171010012 10800 3601 604800 86400
+
+;; AUTHORITY SECTION:
+archives.gov.		300	IN	NS	sauthns1.qwest.net.
+archives.gov.		300	IN	NS	sauthns2.qwest.net.
+
+;; Query time: 154 msec
+;; SERVER: 63.150.72.5#53(63.150.72.5)
+;; WHEN: Fri Oct 13 23:41:34 CEST 2017
+;; MSG SIZE  rcvd: 150
+```
+
+## Proposed fix
+
+The problem may be caused by an outdated version of *NSD: Name Server Daemon* from *NLnet Labs* being used on these DNS servers
+(version 3.2.2 from May 2009).
+
+The DNS server software should be patched or upgraded - a vendor page says that:
+> NSD 3.x is end of life. We now provide support for NSD 4. Please upgrade to NSD 4.
+
+## Workaround
+
+Disable EDNS or attaching of any EDNS options to a DNS query by a resolver when interacting with these DNS servers (if possible).
+
+## DNS Operator/Vendor Response
+
+Operator was notified October 13, 2017 via *ipadmin@centurylink.com* address
+(after *dns-admin@qwestip.net* address found in SOA records returned an automatic response that that mailbox is no longer available).
+
+When a reply is received this entry will be updated.
+
+## Metadata
+
+Submitter: Maciej S. Szmigiero
+Submit-Date: 2017-10-13
+Report-Date: 2017-10-13
+Tags: protocol, edns


### PR DESCRIPTION
This PR adds a DVE about *sauthns1.qwest.net* and *sauthns2.qwest.net* DNS servers that respond incorrectly to EDNS requests that contain any option unknown to them (for example a *COOKIE* option) -
they return RCODE of *BADVERS* instead of ignoring the unknown option(s).

Many .GOV domains (like *archives.gov*, *arts.gov*, *bea.gov*, etc.) are served by these DNS servers.

The operator was notified, when a reply is received this entry will be updated.
