### PR TITLE
Ubuntu 17.10+ fails captive portal authentication with arubanetworks captive portals

### DIFF
--- a/2018/DVE-2018-0001.md
+++ b/2018/DVE-2018-0001.md
@@ -1,4 +1,4 @@
-# DVE-2017-0001: securelogin.arubanetworks.com captive Wi-Fi portals fail to authorise with Ubuntu 17.10+ / systemd-resolved clients
+# DVE-2018-0001: securelogin.arubanetworks.com captive Wi-Fi portals fail to authorise with Ubuntu 17.10+ / systemd-resolved clients
 
 ## Description
 

--- a/2018/DVE-2018-0001.md
+++ b/2018/DVE-2018-0001.md
@@ -1,0 +1,110 @@
+# DVE-2017-0001: securelogin.arubanetworks.com captive Wi-Fi portals fail to authorise with Ubuntu 17.10+ / systemd-resolved clients
+
+## Description
+
+Ubuntu 17.10+ uses systemd-resolved local caching stub resolver
+(127.0.0.53) for system dns resolutions. When trying to connect and
+authorise with the captive portal at securelogin.arubanetworks.com, at
+some point it fails to resolve correctly and thus users are failing to
+pass captive portal authorisation and access internet.
+
+Originally this was reports on Ubuntu bug tracker at
+https://bugs.launchpad.net/ubuntu/+source/systemd/+bug/1727237
+
+This might be a bug in Ubuntu/systemd-resolved and/or
+securelogin.arubanetworks.com DNS spoofing/captivity and/or both.
+
+## Evidence
+
+### From launchpad bug report
+
+```
+NSLOOKUP:
+
+~$ nslookup securelogin.arubanetworks.com 208.67.220.220
+Server:	208.67.220.220
+Address:	208.67.220.220#53
+
+Non-authoritative answer:
+Name:	securelogin.arubanetworks.com
+Address: 172.22.240.242
+
+~$ nslookup securelogin.arubanetworks.com 208.67.222.222
+Server:	208.67.222.222
+Address:	208.67.222.222#53
+
+Non-authoritative answer:
+Name:	securelogin.arubanetworks.com
+Address: 172.22.240.242
+
+PING:
+
+~$ ping securelogin.arubanetworks.com
+ping: securelogin.arubanetworks.com: Name or service not known
+mark@mark-X1Y2:~$
+
+DIG:
+
+~$ dig @208.67.222.222 securelogin.arubanetworks.com
+
+; <<>> DiG 9.10.3-P4-Ubuntu <<>> @208.67.222.222 securelogin.arubanetworks.com
+; (1 server found)
+;; global options: +cmd
+;; Got answer:
+;; ->>HEADER<<- opcode: QUERY, status: NXDOMAIN, id: 9416
+;; flags: qr rd ra; QUERY: 1, ANSWER: 0, AUTHORITY: 1, ADDITIONAL: 1
+
+;; OPT PSEUDOSECTION:
+; EDNS: version: 0, flags:; udp: 4096
+;; QUESTION SECTION:
+;securelogin.arubanetworks.com.	IN	A
+
+;; AUTHORITY SECTION:
+arubanetworks.com.	1991	IN	SOA	dns5.arubanetworks.com. hostmaster.arubanetworks.com. 1323935888 3600 200 1209600 86400
+
+;; Query time: 34 msec
+;; SERVER: 208.67.222.222#53(208.67.222.222)
+;; WHEN: Wed Oct 25 10:31:10 CEST 2017
+;; MSG SIZE rcvd: 144
+
+MORE DIG:
+
+~$ dig securelogin.arubanetworks.com
+
+; <<>> DiG 9.10.3-P4-Ubuntu <<>> securelogin.arubanetworks.com
+;; global options: +cmd
+;; Got answer:
+;; ->>HEADER<<- opcode: QUERY, status: NXDOMAIN, id: 3924
+;; flags: qr rd ra; QUERY: 1, ANSWER: 0, AUTHORITY: 0, ADDITIONAL: 1
+
+;; OPT PSEUDOSECTION:
+; EDNS: version: 0, flags:; udp: 65494
+;; QUESTION SECTION:
+;securelogin.arubanetworks.com.	IN	A
+
+;; Query time: 0 msec
+;; SERVER: 127.0.0.53#53(127.0.0.53)
+;; WHEN: Wed Oct 25 10:34:01 CEST 2017
+;; MSG SIZE rcvd: 58
+```
+
+## Proposed fix
+
+There are currently no proposed fixes, as Ubuntu developers are trying to find captive arubanetworks.com Wi-Fi.
+Any assistance in locating and/or debugging this captive portal would be highly appreciated.
+
+Previous version of Ubuntu were using resolvconf, optionally with a
+local dnsmasq caching resolving dns client, which did work with these
+captive portals.
+
+## Workaround
+
+No workarounds are currently known.
+
+## Files
+
+None at the moment.
+
+## Metadata
+
+Tags: captive-portal


### PR DESCRIPTION

Signed-off-by: Dimitri John Ledkov <xnox@ubuntu.com>