### PR TITLE
record vendor fix date (2018-12-14)

### DIFF
--- a/2018/DVE-2018-0004.md
+++ b/2018/DVE-2018-0004.md
@@ -77,4 +77,5 @@ None at the moment.
 
 ## Metadata
 
+Fixed-Date: 2018-12-14 (dns load balancer vendor patched it; verified)
 Tags: load-balancer


### PR DESCRIPTION
the firstrepublic.com team worked with their dns load balancer vendor to get this fixed. it now responds correctly to qtype=NS.