### PR TITLE
DVE-2020-0003

### DIFF
--- a/2020/DVE-2020-0003.md
+++ b/2020/DVE-2020-0003.md
@@ -1,0 +1,57 @@
+# DVE-2020-0003: mail.protection.outlook.com nameservers fail to respond correctly to some in-bailiwick queries
+
+## Description
+
+The zone mail.protection.outlook.com has two nameservers:
+
+```
+$ dig +dnssec +short ns mail.protection.outlook.com
+ns1-proddns.glbdns.o365filtering.com.
+ns2-proddns.glbdns.o365filtering.com.
+```
+
+Queries to these nameservers using EDNS0 fail as detailed in DVE-2020-0001.
+Queries to these nameservers without EDNS for subdomains of mail.protection.outlook.com that contain an underscore ('_') character result in a FORMERR response code.
+
+[RFC 1035](https://tools.ietf.org/html/rfc1035) section 4.3.2 specifies the following nameserver behaviour:
+
+  > Start matching down, label by label, in the zone.  The matching process can terminate several ways:
+  > ....
+  > c. If at some label, a match is impossible (i.e., the corresponding label does not exist), look to see if a the "*" label exists.
+  > ....
+  >    If the "*" label does not exist, check whether the name we are looking for is the original QNAME in the query or a name we have followed due to a CNAME.  If the name is original, set an authoritative name error in the response and exit.
+
+The correct response to a query for a non-existent node is NXDOMAIN.  Responding with a FORMERR response code can result in a recursive resolver discarding the nameserver from its SLIST and querying the next, eventually having to return SERVFAIL to the client.  Resolvers that keep statistical information about nameserver behaviour may eventually suspend queries to these nameservers due to repeated queries that contain an underscore ('_') character.
+
+## Evidence
+
+Evidence is provided here for one nameserver.  Both nameservers behave in the same way.
+
+```
+$ dig +noedns +norecurse blah_blah.mail.protection.outlook.com @ns1-proddns.glbdns.o365filtering.com
+
+; <<>> DiG 9.11.5-P4-5.1-Debian <<>> +noedns +norecurse blah_blah.mail.protection.outlook.com @ns1-proddns.glbdns.o365filtering.com
+;; global options: +cmd
+;; Got answer:
+;; ->>HEADER<<- opcode: QUERY, status: FORMERR, id: 24259
+;; flags: qr; QUERY: 0, ANSWER: 0, AUTHORITY: 0, ADDITIONAL: 0
+
+;; Query time: 26 msec
+;; SERVER: 104.47.118.145#53(104.47.118.145)
+;; WHEN: Sat May 30 00:03:43 UTC 2020
+;; MSG SIZE  rcvd: 12
+```
+
+## Proposed fix
+
+Nameservers should respond with a response code of NXDOMAIN (3) to queries for non-existent nodes.
+
+## DNS Operator/Vendor Response
+
+It has not been possible to contact the vendor.
+
+## Metadata
+
+Submitter: Brian Somers
+Submit-Date: 2020-05-29
+Tags: FORMERR


### PR DESCRIPTION
mail.protection.outlook.com nameservers fail to respond correctly to some
in-bailiwick queries