### PR TITLE
Add vendor update reference to DVE-2018-0001

### DIFF
--- a/2018/DVE-2018-0001.md
+++ b/2018/DVE-2018-0001.md
@@ -24,6 +24,11 @@ Special thanks to Mario Limonciello (https://github.com/superm1) from
 Dell Inc for performing necessory packet captures to troubleshoot this
 error.
 
+Thanks to Herman Robers from Aruba Networks for identification of
+affected Aruba Instant version and
+[fixed version AOS-222843](https://www.arubanetworks.com/techdocs/Instant_8.x_RN_WebHelp/Content/8.6/17/resolved-issues-86017.htm?Highlight=AOS-222843)
+ identificator.
+
 ## Evidence
 
 ### From launchpad bug report
@@ -103,13 +108,19 @@ MORE DIG:
 Manufacturers of the captive portals should correctly support EDNS0
 queries and EDNS0 queries with DO bit zero.
 
+Update to [ArubaOS 8.6.17: AOS-222843](https://www.arubanetworks.com/techdocs/Instant_8.x_RN_WebHelp/Content/8.6/17/resolved-issues-86017.htm?Highlight=AOS-222843) or later on the AP.
+
 ## Workaround
 
 In systemd-resolved, when performing lookup of domain names with
-'secure' in them, and receiving NXDOMAIN repsonse, retry again without
+'secure' in them, and receiving NXDOMAIN response, retry again without
 EDNS0.
 
-https://github.com/systemd/systemd/pull/8608
+- https://github.com/systemd/systemd/pull/8608
+- https://github.com/systemd/systemd/pull/18638
+
+Send queries without EDNS0 during connectivity check, until captive portal
+is passed.
 
 ## Files
 


### PR DESCRIPTION
With help of Herman Robers from Aruba support we found which version of ArubaOS were responsible and when it was fixed. Updating proposed fix to update the AP firmware.