### PR TITLE
Selective forwarding has to ignore EDNS

### DIFF
--- a/2018/DVE-2018-0001.md
+++ b/2018/DVE-2018-0001.md
@@ -106,11 +106,19 @@ MORE DIG:
 ## Proposed fix
 
 Manufacturers of the captive portals should correctly support EDNS0
-queries and EDNS0 queries with DO bit zero.
+queries and EDNS0 queries with DO bit zero. If *some* names are handled
+or forwarded a special way, servers answering them *must* stay the same
+regardless EDNS0 presence or DO bit value.
 
-Update to [ArubaOS 8.6.17: AOS-222843](https://www.arubanetworks.com/techdocs/Instant_8.x_RN_WebHelp/Content/8.6/17/resolved-issues-86017.htm?Highlight=AOS-222843) or later on the AP.
+## Vendor response
+
+Update to [ArubaOS 8.6.17: AOS-222843](https://www.arubanetworks.com/techdocs/Instant_8.x_RN_WebHelp/Content/8.6/17/resolved-issues-86017.htm?Highlight=AOS-222843)
+or later on the AP providing the captive portal.
 
 ## Workaround
+
+Send queries without EDNS0 during connectivity check, until the captive portal
+is passed.
 
 In systemd-resolved, when performing lookup of domain names with
 'secure' in them, and receiving NXDOMAIN response, retry again without
@@ -118,9 +126,6 @@ EDNS0.
 
 - https://github.com/systemd/systemd/pull/8608
 - https://github.com/systemd/systemd/pull/18638
-
-Send queries without EDNS0 during connectivity check, until captive portal
-is passed.
 
 ## Files
 


### PR DESCRIPTION
Add additional comment, which might affect caches like dnsmasq. In case the cache overrides some name and answers for it itself, it must not make different decision based on optional flags or sections.

Cannot forward all DO=1 or EDNS0 queries upstream, if works as authoritative zone for the name.